### PR TITLE
feat(readme): Add an appendix and re-word

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Project Name
+## Overview
 
-A short single paragraph description of the project and what it does
+A concise description of the project and what it does
 
 ## Prerequisites
 
@@ -14,24 +14,23 @@ List any prerequisites here, such as:
 
 A short description of how to get up and running with the project locally. It
 should not be much more than the below for front end applications. For back-end
-applications, this may need to be more verbose.
+applications, this will need to be more verbose.
 
 * Clone the repository
 * Install dependancies: `yarn`
 * Start development server: `yarn start`
 * Navigate to <https://localhost:3000> in your browser
 
-## Running the tests
+## Testing
 
 A description of how to run the test suite associated with the application.
 
-## Contributing
+## Deployment
 
-Please read [CONTRIBUTING.md][contributing] for details on how to contribute to
-this project, including coding standards, commit message requirements and the
-process for submitting pull requests.
+Describe the deployment process in short here, with a link to [DEPLOYMENTS][dep]
+if necessary.
 
-## Further Documentation
+## Documentation
 
 Detailed documentation can be found on [Confluence][confluence]:
 
@@ -39,23 +38,28 @@ Detailed documentation can be found on [Confluence][confluence]:
 * Project Architecture
 * Project Guidelines
 
-## Branching Strategy
+## Appendix
+
+Use this section for any additional headings relevant for your project. Any sections prior to this point should be kept consistent, concise and to the point.
+
+### Contributing
+
+Please read [CONTRIBUTING.md][contributing] for details on how to contribute to
+this project, including coding standards, commit message requirements and the
+process for submitting pull requests.
+
+### Branching Strategy
 
 Please don't work directly on master. Use a topic branch appropriate for the
 type of work you are doing. Refer the the [branching strategy][branch] for this.
 More detailed guidelines are documented in [CONTRIBUTING.md][contributing].
 
-## Deployment
-
-Describe the deployment process in short here, with a link to [DEPLOYMENTS][dep]
-if necessary.
-
-## Versioning
+### Versioning
 
 We use [SemVer][semver] for versioning. For the versions available, see the 
 [tags on this repository][tags]. 
 
-## Code Owners/Subject Matter Experts
+### Code Owners
 
 See the [CODEOWNERS](codeowners) file for a list of subject matter experts with 
 whom to speak.


### PR DESCRIPTION
I've made changes to suit my personal tastes.

The main contribution is the Appendix heading, with the disclaimer to keep prior sections concise. I think this is valuable because many projects often have important things they want to describe in the readme, but this often comes at the cost of diluting the readme and making it harder to get the critical information you need. An appendix keeps the critical top-level content concise without preventing authors from adding additional headings. 